### PR TITLE
added yaml 1.2.2 compatibility

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -25,14 +25,14 @@ rules:
     level: error
   indentation:
     spaces: 2
-    indent-sequences: yes
-    check-multi-line-strings: no
+    indent-sequences: true
+    check-multi-line-strings: false
     level: warning
   key-duplicates: enable
   line-length:
     max: 80
-    allow-non-breakable-words: yes
-    allow-non-breakable-inline-mappings: yes
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
     level: warning
   new-line-at-end-of-file: disable
   new-lines:
@@ -40,4 +40,4 @@ rules:
   trailing-spaces: disable
   truthy:
     allowed-values: ['YES', 'Yes', 'yes', 'NO', 'No', 'no']
-    check-keys: no
+    check-keys: false

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -2,4 +2,4 @@
 
 - name: Cleanup
   hosts: molecule_hosts
-  gather_facts: no
+  gather_facts: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 
 - name: Converge
   hosts: molecule_hosts
-  gather_facts: yes
+  gather_facts: true
   roles:
     - role: amtega.select_hostvars
       vars:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,10 +2,10 @@
 
 dependency:
   name: galaxy
-  enabled: yes
+  enabled: true
   options:
-    ignore-certs: yes
-    ignore-errors: yes
+    ignore-certs: true
+    ignore-errors: true
     role-file: "${MOLECULE_SCENARIO_DIRECTORY}/requirements.yml"
     requirements-file: "${MOLECULE_SCENARIO_DIRECTORY}/requirements.yml"
 driver:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,4 +2,4 @@
 
 - name: Prepare
   hosts: molecule_hosts
-  gather_facts: no
+  gather_facts: false

--- a/molecule/default/side_effect.yml
+++ b/molecule/default/side_effect.yml
@@ -2,4 +2,4 @@
 
 - name: Side effects
   hosts: molecule_hosts
-  gather_facts: no
+  gather_facts: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,4 +2,4 @@
 
 - name: Verify
   hosts: molecule_hosts
-  gather_facts: no
+  gather_facts: false


### PR DESCRIPTION
in the newer yaml spec yes/no/on/off are no longer interpreted as boolean but as string. changing those to true/false fixes this.